### PR TITLE
Add feature to generate embeddable html string

### DIFF
--- a/lib/plotly/offline/exportable.rb
+++ b/lib/plotly/offline/exportable.rb
@@ -20,6 +20,11 @@ module Plotly
         Launchy.open(File.absolute_path(path)) if open
       end
 
+      def to_html
+        html = create_html(@data, layout: @layout, embedded: true)
+        html.render
+      end
+
       private
 
       def create_html(data, layout: {}, embedded: false)


### PR DESCRIPTION
I implemented `Plotly::Plot#to_html` method. It generates embeddable html string.

With this method, we can embed graphs in other web apps easily like this:

```erb
<h1> This is graph! </h1>

<%= @plot.to_html %>

```