### PR TITLE
add default_auth

### DIFF
--- a/lib/plotly/client.rb
+++ b/lib/plotly/client.rb
@@ -1,6 +1,6 @@
-require 'faraday'
-require 'base64'
-require 'json'
+require "faraday"
+require "base64"
+require "json"
 
 module Plotly
   class Client
@@ -10,8 +10,8 @@ module Plotly
     # @param api_key [String]
     def initialize(username, api_key)
       @conn = Faraday.new(
-        url: 'https://api.plot.ly/v2',
-        headers: build_headers(username, api_key)
+        url: "https://api.plot.ly/v2",
+        headers: build_headers(username, api_key),
       )
     end
 
@@ -23,9 +23,9 @@ module Plotly
     def build_headers(username, api_key)
       encoded_auth = Base64.encode64("#{username}:#{api_key}")
       {
-        'plotly-client-platform' => "Ruby #{Plotly::VERSION}",
-        'content-type' => 'application/json',
-        authorization: "Basic #{encoded_auth}"
+        "plotly-client-platform" => "Ruby #{Plotly::VERSION}",
+        "content-type" => "application/json",
+        authorization: "Basic #{encoded_auth}",
       }
     end
   end
@@ -36,10 +36,36 @@ module Plotly
       @client = Client.new(username, api_key)
     end
 
+    # Set the default client
+    def default_auth()
+      #      @client = @client || Client.new(ENV['PLOTLY_USERNAME'], ENV['PLOTLY_API_KEY'])
+      default_path = File.join(ENV["HOME"], ".plotly", ".credentials")
+      credentials = JSON.load(File.read(default_path))
+      @client = Client.new(credentials["username"], credentials["api_key"])
+      #      @client = Client.new(username, api_key)
+    end
+
+    # Set the credentials for a specific client
+    def set_credentials_file(username, api_key,
+                             opts = { proxy_username: "",
+                                      proxy_password: "",
+                                      stream_ids: [] })
+      credentials = {
+        "username" => username,
+        "api_key" => api_key,
+        "proxy_username": opts[:proxy_username],
+        "proxy_password": opts[:proxy_password],
+        "stream_ids": opts[:stream_ids],
+      }
+      File.open(File.join(ENV["HOME"], ".plotly", ".credentials"), "w") do |f|
+        f.write(JSON.pretty_generate(credentials))
+      end
+    end
+
     # @return [Plotly::Client]
     # @raise [RuntimeError]
     def client
-      @client ? @client : raise('Authentication required')
+      @client ? @client : raise("Authentication required")
     end
   end
 end


### PR DESCRIPTION
Thanks for the useful gem.  I really use it pretty often.
Now I will nbconvert the notebook to operate batch jobs,
the Plotly.show should be necessary to change the download_image.
Although the README recommends to use Plotly.auth each time,
I think it is more convenient to use the default credential file for Plotly.
Thus I added,
- default_auth
- set_credentials_file
in client.rb.

Hope to accept the pull request.

Usage
- Plotly.set_credentials_file(user_name, user_token)
- Plotly.default_auth
